### PR TITLE
create commands for enocean

### DIFF
--- a/lib/tahoma.js
+++ b/lib/tahoma.js
@@ -758,7 +758,8 @@ Tahoma.prototype.updateDevice = function (name, deviceData) {
 
         if ((deviceData.deviceURL.startsWith("io:") && (command.nparams === 0)) ||
             (deviceData.deviceURL.startsWith("rts:") && (command.nparams <= 1)) ||
-            (deviceData.deviceURL.startsWith("ogp:") && (command.nparams <= 1))) {
+            (deviceData.deviceURL.startsWith("ogp:") && (command.nparams <= 1)) ||
+            (deviceData.deviceURL.startsWith("enocean:") && (command.nparams === 0))) {
             controller.createOrUpdateState(name + ".commands." + command.commandName, false, {
                 "type": "boolean",
                 "read": true,


### PR DESCRIPTION
Hello Excodibur,

I added a one-liner to support my eltaco-enocean-actors. I control them with the tahoma-enocean-usb-stick. They have an on-command and  an off-command without params.

Best regards
Lowadeth