### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "type": "git",
     "url": "https://github.com/Excodibur/ioBroker.tahoma"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "@strathcole/iob-lib": "^0.1.0",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installed at node 14 due to npm 6 not installing peerDependencies. So this adapter requires node 16 or newer to ensure a working installation.