### PR TITLE
Update build-test-release.yml - add node 20 tests, remove node 14

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -21,7 +21,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [16.x, 18.x]
+                node-version: [16.x, 18.x, 20.x]
 
         steps:
             - uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                node-version: [16.x, 18.x]
+                node-version: [16.x, 18.x, 20.x]
                 os: [ubuntu-latest, macos-latest]
 
         steps:
@@ -103,7 +103,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [14.x]
+                node-version: [18.x]
 
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Please check and merge PR to add node 20 tests.

Node 20 is stable in meantime and fully supported by ioBroker (although node 18 is still the recommended release). So all adapters should be tested aith node 20.

If there are know restrictions with node 20.x it's ok to temporary supend tests but cratea a issue describing the problem and try to fix it as soon asyour time allows.

Thanks
mcm1957